### PR TITLE
Update instances.yaml for support upstream

### DIFF
--- a/tungsten_50_deploy/all-in-one-os/instances.yaml
+++ b/tungsten_50_deploy/all-in-one-os/instances.yaml
@@ -39,8 +39,8 @@ kolla_config:
     keystone_admin_password: contrail123
 global_configuration:
   CONTAINER_REGISTRY: opencontrailnightly
-  CONTRAIL_VERSION: latest
 contrail_configuration:
+  CONTRAIL_VERSION: latest
   CLOUD_ORCHESTRATOR: openstack
   UPGRADE_KERNEL: true
   CONTROL_DATA_NET_LIST: 192.168.122.0/24

--- a/tungsten_50_deploy/all-in-one-os/instances.yaml
+++ b/tungsten_50_deploy/all-in-one-os/instances.yaml
@@ -37,7 +37,7 @@ kolla_config:
     enable_heat: no
   kolla_passwords:
     keystone_admin_password: contrail123
-contrail_configuration:
+global_configuration:
   CONTAINER_REGISTRY: opencontrailnightly
   CONTRAIL_VERSION: latest
   CLOUD_ORCHESTRATOR: openstack

--- a/tungsten_50_deploy/all-in-one-os/instances.yaml
+++ b/tungsten_50_deploy/all-in-one-os/instances.yaml
@@ -40,6 +40,7 @@ kolla_config:
 global_configuration:
   CONTAINER_REGISTRY: opencontrailnightly
   CONTRAIL_VERSION: latest
+contrail_configuration:
   CLOUD_ORCHESTRATOR: openstack
   UPGRADE_KERNEL: true
   CONTROL_DATA_NET_LIST: 192.168.122.0/24


### PR DESCRIPTION
Hi urao,

When I deployed it, I noticed an unfamiliar error.
```
TASK [install_contrail : set registry if defined] **********************************************************************************************************************************************
fatal: [192.168.121.6]: FAILED! => {"msg": "The conditional check 'global_configuration.CONTAINER_REGISTRY is defined' failed. The error was: error while evaluating conditional (global_configuration.CONTAINER_REGISTRY is defined): 'global_configuration' is undefined\n\nThe error appears to have been in '/root/contrail-ansible-deployer/playbooks/roles/install_contrail/tasks/main.yml': line 76, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: set registry if defined\n  ^ here\n"}
        to retry, use: --limit @/root/contrail-ansible-deployer/playbooks/install_contrail.retry

PLAY RECAP *************************************************************************************************************************************************************************************
```

I found that there was a change in the Juniper/contrail-ansible-deployer repository as a result of investigation.
[commit ec09835a50925868d65cd61b9eeedab2d3bce11a](https://github.com/Juniper/contrail-ansible-deployer/commit/ec09835a50925868d65cd61b9eeedab2d3bce11a)

Please make sure.
